### PR TITLE
python: Changes required in order to build on newer gcc compiler 9.4 

### DIFF
--- a/Include/pymem.h
+++ b/Include/pymem.h
@@ -72,9 +72,9 @@ PyAPI_FUNC(void) PyMem_Free(void *);
 /* Returns NULL to indicate error if a negative size or size larger than
    Py_ssize_t can represent is supplied.  Helps prevents security holes. */
 #define PyMem_MALLOC(n)		((size_t)(n) > (size_t)PY_SSIZE_T_MAX ? NULL \
-				: malloc((n) ? (n) : 1))
+				: malloc((n) != 0? (n) : 1))
 #define PyMem_REALLOC(p, n)	((size_t)(n) > (size_t)PY_SSIZE_T_MAX  ? NULL \
-				: realloc((p), (n) ? (n) : 1))
+				: realloc((p), (n) != 0? (n) : 1))
 #define PyMem_FREE		free
 
 #endif	/* PYMALLOC_DEBUG */

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -3704,6 +3704,9 @@ _build_callargs(PyCFuncPtrObject *self, PyObject *argtypes,
             *pinoutmask |= (1 << i); /* mark as inout arg */
             (*pnumretvals)++;
             /* fall through to PARAMFLAG_FIN... */
+#if defined(__GNUC__) && __GNUC__ >= 7
+	    __attribute__ ((fallthrough));
+#endif
         case 0:
         case PARAMFLAG_FIN:
             /* 'in' parameter.  Copy it from inargs. */

--- a/Modules/zlib/inflate.c
+++ b/Modules/zlib/inflate.c
@@ -85,6 +85,10 @@
 #include "inflate.h"
 #include "inffast.h"
 
+#if defined(__GNUC__) && __GNUC__ >= 7
+#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
+
 #ifdef MAKEFIXED
 #  ifndef BUILDFIXED
 #    define BUILDFIXED

--- a/Objects/stringobject.c
+++ b/Objects/stringobject.c
@@ -590,6 +590,7 @@ string_dealloc(PyObject *op)
 
         case SSTATE_INTERNED_IMMORTAL:
             Py_FatalError("Immortal interned string died.");
+	    // fall through
 
         default:
             Py_FatalError("Inconsistent interned string state.");

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -796,6 +796,9 @@ PyUnicode_FromFormatV(const char *format, va_list vargs)
 #endif
                 /* fall through... */
             }
+#if defined(__GNUC__) && __GNUC__ >= 7
+	    __attribute__ ((fallthrough));
+#endif
             case '%':
                 n++;
                 break;

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -2284,7 +2284,7 @@ ast_for_print_stmt(struct compiling *c, const node *n)
         dest = ast_for_expr(c, CHILD(n, 2));
         if (!dest)
             return NULL;
-            start = 4;
+        start = 4;
     }
     values_count = (NCH(n) + 1 - start) / 2;
     if (values_count) {

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -2623,14 +2623,14 @@ ast_for_import_stmt(struct compiling *c, const node *n)
             alias_ty import_alias = alias_for_import_name(c, n, 1);
             if (!import_alias)
                 return NULL;
-                asdl_seq_SET(aliases, 0, import_alias);
+            asdl_seq_SET(aliases, 0, import_alias);
         }
         else {
             for (i = 0; i < NCH(n); i += 2) {
                 alias_ty import_alias = alias_for_import_name(c, CHILD(n, i), 1);
                 if (!import_alias)
                     return NULL;
-                    asdl_seq_SET(aliases, i / 2, import_alias);
+                asdl_seq_SET(aliases, i / 2, import_alias);
             }
         }
         if (mod != NULL)

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -549,6 +549,7 @@ ast_for_comp_op(struct compiling *c, const node *n)
                     return In;
                 if (strcmp(STR(n), "is") == 0)
                     return Is;
+		break;
             default:
                 PyErr_Format(PyExc_SystemError, "invalid comp_op: %s",
                              STR(n));
@@ -563,6 +564,7 @@ ast_for_comp_op(struct compiling *c, const node *n)
                     return NotIn;
                 if (strcmp(STR(CHILD(n, 0)), "is") == 0)
                     return IsNot;
+		break;
             default:
                 PyErr_Format(PyExc_SystemError, "invalid comp_op: %s %s",
                              STR(CHILD(n, 0)), STR(CHILD(n, 1)));
@@ -2417,6 +2419,7 @@ ast_for_flow_stmt(struct compiling *c, const node *n)
                 return Raise(expr1, expr2, expr3, LINENO(n), n->n_col_offset,
                              c->c_arena);
             }
+	    break;
         default:
             PyErr_Format(PyExc_SystemError,
                          "unexpected flow_stmt: %d", TYPE(ch));

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2694,7 +2694,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
                 JUMPTO(oparg);
             else
                 break;
-        	DISPATCH();
+            DISPATCH();
         }
 
         PREDICTED_WITH_ARG(POP_JUMP_IF_TRUE);
@@ -2720,7 +2720,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
                 ;
             else
                 break;
-        	DISPATCH();
+            DISPATCH();
         }
 
         TARGET(JUMP_IF_FALSE_OR_POP)
@@ -2745,7 +2745,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
                 JUMPTO(oparg);
             else
                 break;
-        	DISPATCH();
+            DISPATCH();
         }
 
         TARGET(JUMP_IF_TRUE_OR_POP)
@@ -2771,7 +2771,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
             }
             else
                 break;
-        	DISPATCH();
+            DISPATCH();
         }
 
         PREDICTED_WITH_ARG(JUMP_ABSOLUTE);
@@ -2829,7 +2829,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
             x = v = POP();
             Py_DECREF(v);
             JUMPBY(oparg);
-        	DISPATCH();
+            DISPATCH();
         }
 
         TARGET_NOARG(BREAK_LOOP)

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -19,6 +19,12 @@
 
 #include <ctype.h>
 
+#if defined(__GNUC__) && __GNUC__ >= 7
+#define fallthrough __attribute__((fallthrough));
+#else
+#define fallthrough ;
+#endif
+
 #ifndef WITH_TSC
 
 #define READ_TIMESTAMP(var)
@@ -724,12 +730,14 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
 #define TARGET_NOARG(op) \
 		TARGET_##op: \
 		opcode = op; \
+	        fallthrough; \
 		case op:\
 
 #define TARGET(op) \
 		TARGET_##op: \
 		opcode = op; \
 		oparg = NEXTARG(); \
+	        fallthrough; \
 		case op:\
 
 
@@ -2057,6 +2065,7 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
                 /* Fallthrough */
             case 1:
                 w = POP(); /* exc */
+		// fall through
             case 0: /* Fallthrough */
                 why = do_raise(w, v, u);
                 break;

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -3079,12 +3079,18 @@ compiler_visit_expr(struct compiler *c, expr_ty e)
         switch (e->v.Attribute.ctx) {
         case AugLoad:
             ADDOP(c, DUP_TOP);
+#if defined(__GNUC__) && __GNUC__ >= 7
+	     __attribute__ ((fallthrough));
+#endif
             /* Fall through to load */
         case Load:
             ADDOP_NAME(c, LOAD_ATTR, e->v.Attribute.attr, names);
             break;
         case AugStore:
             ADDOP(c, ROT_TWO);
+#if defined(__GNUC__) && __GNUC__ >= 7
+	     __attribute__ ((fallthrough));
+#endif
             /* Fall through to save */
         case Store:
             ADDOP_NAME(c, STORE_ATTR, e->v.Attribute.attr, names);

--- a/Python/dtoa.c
+++ b/Python/dtoa.c
@@ -1527,6 +1527,9 @@ _Py_dg_strtod(const char *s00, char **se)
     switch (c) {
     case '-':
         sign = 1;
+#if defined(__GNUC__) && __GNUC__ >= 7
+	 __attribute__ ((fallthrough));
+#endif
         /* no break */
     case '+':
         c = *++s;
@@ -1596,6 +1599,9 @@ _Py_dg_strtod(const char *s00, char **se)
         switch (c) {
         case '-':
             esign = 1;
+#if defined(__GNUC__) && __GNUC__ >= 7
+	     __attribute__ ((fallthrough));
+#endif
             /* no break */
         case '+':
             c = *++s;
@@ -2514,6 +2520,9 @@ _Py_dg_dtoa(double dd, int mode, int ndigits,
         break;
     case 2:
         leftright = 0;
+#if defined(__GNUC__) && __GNUC__ >= 7
+	 __attribute__ ((fallthrough));
+#endif
         /* no break */
     case 4:
         if (ndigits <= 0)
@@ -2522,6 +2531,9 @@ _Py_dg_dtoa(double dd, int mode, int ndigits,
         break;
     case 3:
         leftright = 0;
+#if defined(__GNUC__) && __GNUC__ >= 7
+	 __attribute__ ((fallthrough));
+#endif
         /* no break */
     case 5:
         i = ndigits + k + 1;

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -1736,6 +1736,9 @@ skipitem(const char **p_format, va_list *p_va, int flags)
                 /* after 'e', only 's' and 't' is allowed */
                 goto err;
             format++;
+#if defined(__GNUC__) && __GNUC__ >= 7
+	     __attribute__ ((fallthrough));
+#endif
             /* explicit fallthrough to string cases */
         }
 

--- a/configure.ac
+++ b/configure.ac
@@ -1121,6 +1121,9 @@ yes)
       BASECFLAGS="$BASECFLAGS -fno-strict-aliasing"
     fi
 
+    # disable cast function type warning for newer compilers
+    BASECFLAGS="$BASECFLAGS -Wno-cast-function-type"
+
     # if using gcc on alpha, use -mieee to get (near) full IEEE 754
     # support.  Without this, treatment of subnormals doesn't follow
     # the standard.


### PR DESCRIPTION
These are all the changes required to build python on the newer gcc 9.4 compiler